### PR TITLE
decoder: Fix crashes found by fuzzer

### DIFF
--- a/ogorek.go
+++ b/ogorek.go
@@ -692,7 +692,11 @@ func (d *Decoder) get() error {
 	if err != nil {
 		return err
 	}
-	d.push(d.memo[string(line)])
+	v, ok := d.memo[string(line)]
+	if !ok {
+		return fmt.Errorf("pickle: memo: key error %q", line)
+	}
+	d.push(v)
 	return nil
 }
 
@@ -702,7 +706,11 @@ func (d *Decoder) binGet() error {
 		return err
 	}
 
-	d.push(d.memo[strconv.Itoa(int(b))])
+	v, ok := d.memo[strconv.Itoa(int(b))]
+	if !ok {
+		return fmt.Errorf("pickle: memo: key error %d", b)
+	}
+	d.push(v)
 	return nil
 }
 
@@ -717,7 +725,11 @@ func (d *Decoder) longBinGet() error {
 		return err
 	}
 	v := binary.LittleEndian.Uint32(b[:])
-	d.push(d.memo[strconv.Itoa(int(v))])
+	vv, ok := d.memo[strconv.Itoa(int(v))]
+	if !ok {
+		return fmt.Errorf("pickle: memo: key error %d", v)
+	}
+	d.push(vv)
 	return nil
 }
 

--- a/ogorek.go
+++ b/ogorek.go
@@ -652,6 +652,9 @@ func (d *Decoder) loadDict() error {
 
 	m := make(map[interface{}]interface{}, 0)
 	items := d.stack[k+1:]
+	if len(items) % 2 != 0 {
+		return fmt.Errorf("pickle: loadDict: odd # of elements")
+	}
 	for i := 0; i < len(items); i += 2 {
 		key := items[i]
 		if !reflect.TypeOf(key).Comparable() {
@@ -869,6 +872,9 @@ func (d *Decoder) loadSetItems() error {
 	l := d.stack[k-1]
 	switch m := l.(type) {
 	case map[interface{}]interface{}:
+		if (len(d.stack) - (k + 1)) % 2 != 0 {
+			return fmt.Errorf("pickle: loadSetItems: odd # of elements")
+		}
 		for i := k + 1; i < len(d.stack); i += 2 {
 			key := d.stack[i]
 			if !reflect.TypeOf(key).Comparable() {

--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -278,6 +278,13 @@ func TestFuzzCrashers(t *testing.T) {
 	crashers := []string{
 		"(dS''\n(lc\n\na2a2a22aasS''\na",
 		"S\n",
+		"((dd",
+		"}}}s",
+		"(((ld",
+		"(dS''\n(lp4\nsg4\n(s",
+		"}((tu",
+		"}((du",
+		"(c\n\nc\n\n\x85Rd",
 	}
 
 	for _, c := range crashers {

--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -256,6 +256,24 @@ func TestMemoOpCode(t *testing.T) {
 
 }
 
+// verify that decode of erroneous input produces error
+func TestDecodeError(t *testing.T) {
+	testv := []string{
+		// all kinds of opcodes to read memo but key is not there
+		"}g1\n.",
+		"}h\x01.",
+		"}j\x01\x02\x03\x04.",
+	}
+	for _, tt := range testv {
+		buf := bytes.NewBufferString(tt)
+		dec := NewDecoder(buf)
+		v, err := dec.Decode()
+		if !(v == nil && err != nil) {
+			t.Errorf("%q: no decode error  ; got %#v, %#v", tt, v, err)
+		}
+	}
+}
+
 func TestFuzzCrashers(t *testing.T) {
 	crashers := []string{
 		"(dS''\n(lc\n\na2a2a22aasS''\na",

--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -285,6 +285,8 @@ func TestFuzzCrashers(t *testing.T) {
 		"}((tu",
 		"}((du",
 		"(c\n\nc\n\n\x85Rd",
+		"}(U\x040000u",
+		"(\x88d",
 	}
 
 	for _, c := range crashers {


### PR DESCRIPTION
Fix all crashes found by fuzz-testing so far (#30):

1) check for whether operand is comparable before using it as map key;
2) check for odd number of elements before doing dict build or setItems;
3) check memo read access for whether key is really present in memo (else nil was wrongly extracted).

Please see details in the individual commit messages.

Thanks beforehand,
Kirill