### PR TITLE
.travis.yml += go1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: go
 go:
   - 1.6
   - 1.7
+  - 1.8
   - tip


### PR DESCRIPTION
Which is currently latest stable go release. Maybe we should also drop
go1.6 .