### PR TITLE
decoder: Fix thinko in PROTO opcode handling

### DIFF
--- a/ogorek.go
+++ b/ogorek.go
@@ -277,8 +277,14 @@ loop:
 		case opMemoize:
 			err = d.loadMemoize()
 		case opProto:
-			v, err := d.r.ReadByte()
-			if err == nil && v != 2 {
+			var v byte
+			v, err = d.r.ReadByte()
+			if err == nil && !(0 <= v && v <= 4) {
+				// We support protocol opcodes for up to protocol 4.
+				//
+				// The PROTO opcode documentation says protocol version must be in [2, 256).
+				// However CPython also loads PROTO with version 0 and 1 without error.
+				// So we allow all supported versions as PROTO argument.
 				err = ErrInvalidPickleVersion
 			}
 


### PR DESCRIPTION
Due to := in

	v, err := d.r.ReadByte()

newly declared err was shadowing outside err and thus even though the
code intent was to treat all protocols != 2 as ErrInvalidPickleVersion,
after leaving the switch err was always =nil and no error was reported.

Fix it by explicitly declaring v and not using := not to shadow err.

We also change the condition for supported protocol version to be in [0, 4] because:

- we already have messages in our testsuite with PROTO opcode and
  version 1, and if we don't adjust the version condition the tests will fail.

- the highest protocol version we support opcodes for is 4.
- even though the documentation for PROTO opcode says version must be >= 2,
  in practice CPython decodes pickles with PROTO and lower version just ok:

	In [18]: pickle.loads("\x80\x02I5\n.")
	Out[18]: 5

	In [19]: pickle.loads("\x80\x01I5\n.")
	Out[19]: 5

	In [20]: pickle.loads("\x80\x00I5\n.")
	Out[20]: 5

  so we don't complain about those lower versions too.