### PR TITLE
fixup! decoder: Fix thinko in PROTO opcode handling (#41)

### DIFF
--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -296,6 +296,9 @@ func TestDecodeError(t *testing.T) {
 		// invalid long format
 		"L123\n.",
 		"L12qL\n.",
+
+		// invalid protocol version
+		"\x80\xffI1\n.",
 	}
 	for _, tt := range testv {
 		buf := bytes.NewBufferString(tt)


### PR DESCRIPTION
Add a test that excersizes whether invalid protocol version is caught
and reported. Without 5c420f85 the test fails like this:

	--- FAIL: TestDecodeError (0.00s)
	    ogorek_test.go:312: "\x80\xffI1\n.": no decode error  ; got 1, <nil>