### PR TITLE
decoder: Really fix dict key comparability check

### DIFF
--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -724,6 +724,9 @@ func TestFuzzCrashers(t *testing.T) {
 		"(c\n\nc\n\n\x85Rd",
 		"}(U\x040000u",
 		"(\x88d",
+		"(]QNd.",       // PersID([])      -> dict
+		"}]QNs.",       // PersID([])      -> setitem
+		"}(]QNI1\nNu.", // PersID([]) ...  -> setitems
 	}
 
 	for _, c := range crashers {

--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -739,6 +739,9 @@ func BenchmarkDecode(b *testing.B) {
 	npickle := 0
 	for _, test := range tests {
 		for _, pickle := range test.picklev {
+			if pickle.err != nil {
+				continue
+			}
 			// not prepending `PROTO <ver>` - decoder should be
 			// able to decode without it.
 			input = append(input, pickle.data...)


### PR DESCRIPTION
The story continues and we have to finally switch to panic/recover instead of reflect.TypeOf(key).Comparable() to catch improper key types. Please see details in the second commit and in https://github.com/kisielk/og-rek/issues/30#issuecomment-423803200.