### PR TITLE
tests: Fix Xloosy

### DIFF
--- a/ogorek_test.go
+++ b/ogorek_test.go
@@ -126,7 +126,16 @@ func Xustrict(name string, object interface{}, picklev ...TestPickle) TestEntry 
 //
 // It should be used only if objectIn contains Go structs.
 func Xloosy(name string, objectIn, objectOut interface{}, picklev ...TestPickle) TestEntry {
-	return TestEntry{name: name, objectIn: objectIn, objectOut: objectOut, picklev: picklev}
+	x := X(name, objectIn, picklev...)
+	x.objectOut = objectOut
+	return x
+}
+
+// Xloosy_uauto is like Xuauto but for Xloosy.
+func Xloosy_uauto(name string, objectIn, objectOut interface{}, picklev ...TestPickle) TestEntry {
+	x := Xuauto(name, objectIn, picklev...)
+	x.objectOut = objectOut
+	return x
 }
 
 func I(input string) TestPickle { return TestPickle{protov: nil, data: input, err: nil} }
@@ -461,7 +470,7 @@ var tests = []TestEntry{
 
 	// loosy encode: decoding back gives another object.
 	// the only case where ogórek encoding is loosy is for Go struct types.
-	Xloosy("[]ogórek.foo{\"Qux\", 4}", []foo{{"Qux", 4}},
+	Xloosy_uauto("[]ogórek.foo{\"Qux\", 4}", []foo{{"Qux", 4}},
 		[]interface{}{map[interface{}]interface{}{"Foo": "Qux", "Bar": int64(4)}},
 
 		// MARK + STRING + INT + DICT + LIST


### PR DESCRIPTION
In b28613c2 (Add StrictUnicode mode) I modified TestEntry to have .strictUnicodeN and .strictUnicodeY fields and adjusted X to set them both to true by default. However I missed to adjust Xloosy, which started to return TestEntry with both .strictUnicodeN=.strictUnicodeY=false which effectively disabled running test entries defined via Xloosy.

-> Fix that by reusing X in Xloosy implementation.

This brings in unnoticed test failures with structs and strings:

    --- FAIL: TestDecode (0.03s)
        --- FAIL: TestDecode/[]ogórek.foo{"Qux",_4}/StrictUnicode=y/"((S\"Foo\"\nS\"Qux\"\nS\"Bar\"\nI4\ndl." (0.00s)
            ogorek_test.go:594: decode:
                have: []interface {}{map[interface {}]interface {}{ogórek.ByteString("Bar"):4, ogórek.ByteString("Foo"):ogórek.ByteString("Qux")}}
                want: []interface {}{map[interface {}]interface {}{"Bar":4, "Foo":"Qux"}}
        --- FAIL: TestDecode/[]ogórek.foo{"Qux",_4}/StrictUnicode=y/"((U\x03FooU\x03QuxU\x03BarK\x04dl." (0.00s)
            ogorek_test.go:594: decode:
                have: []interface {}{map[interface {}]interface {}{ogórek.ByteString("Bar"):4, ogórek.ByteString("Foo"):ogórek.ByteString("Qux")}}
                want: []interface {}{map[interface {}]interface {}{"Bar":4, "Foo":"Qux"}}
    --- FAIL: TestEncode (0.11s)
        --- FAIL: TestEncode/[]ogórek.foo{"Qux",_4}/StrictUnicode=y/proto=0 (0.00s)
            ogorek_test.go:670: encode:
                have: "((VFoo\nVQux\nVBar\nI4\ndl."
                want: "((S\"Foo\"\nS\"Qux\"\nS\"Bar\"\nI4\ndl."
        --- FAIL: TestEncode/[]ogórek.foo{"Qux",_4}/StrictUnicode=y/proto=1 (0.00s)
            ogorek_test.go:670: encode:
                have: "((X\x03\x00\x00\x00FooX\x03\x00\x00\x00QuxX\x03\x00\x00\x00BarK\x04dl."
                want: "((U\x03FooU\x03QuxU\x03BarK\x04dl."
        --- FAIL: TestEncode/[]ogórek.foo{"Qux",_4}/StrictUnicode=y/proto=2 (0.00s)
            ogorek_test.go:670: encode:
                have: "\x80\x02((X\x03\x00\x00\x00FooX\x03\x00\x00\x00QuxX\x03\x00\x00\x00BarK\x04dl."
                want: "\x80\x02((U\x03FooU\x03QuxU\x03BarK\x04dl."

because in that test data are prepared to auto strings mode and started to fail with StrictUnicode=y. Fix that by adjusting that test to run in StrictUnicode=n mode only.